### PR TITLE
Remove serve from development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "react-dev-utils": "^5.0.0",
     "react-router": "^4.2.0",
     "request": "^2.34",
-    "serve": "^6.4.3",
     "sinon": "^4.1.2",
     "sloc": "^0.2.0",
     "storybook-host": "^4.1.4",


### PR DESCRIPTION
This is not required by anything, so can be removed altogether. `serve` is often useful to have installed within your development environment, but you should just install it using `yarn global add serve`.

This will remove the security alert relating to `serve < 7.0.0`.

### Definition of Done

* [ ] Code has been peer reviewed
* [x] Test coverage has been maintained or improved
* [x] All tests pass within CI
* [x] README is up to date
